### PR TITLE
added apiListener to transactionHandler.go

### DIFF
--- a/api/handlers/transactionHandler.go
+++ b/api/handlers/transactionHandler.go
@@ -23,7 +23,7 @@ func ConstructBfTx(transaction bf_tx.BF_TX) (interface{}, error) {
 	if err := transaction.GenerateBFTX(common.ORIGIN_API); err != nil {
 		return nil, err
 	}
-
+	bftx_logger.ApiListener(transaction.Id)
 	return transaction, nil
 }
 


### PR DESCRIPTION
Transactions created by the api now have their associated IDs placed in the logs directory